### PR TITLE
Add default 'params' value

### DIFF
--- a/instagram-v1-1.0.js
+++ b/instagram-v1-1.0.js
@@ -20,7 +20,10 @@
   var _accessToken = '';
 
   function wrappedHttpRequest(url, params, authenticateRequest) {
+
+    params = typeof params !== 'undefined' ? params : {};
     authenticateRequest = authenticateRequest || false;
+
     if (authenticateRequest) {
       params.access_token = _accessToken;
     } else {


### PR DESCRIPTION
Allows to call getUser() function (or other functions) without init the 'params' parameter with an empty object :

`ig.getUser(1234)` instead of `ig.getUser(1234, {})`.
